### PR TITLE
Remove the run as login shell flag in entrypoint

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/sh -l
+#!/bin/sh
 
 set -e
 


### PR DESCRIPTION
### Fixed

- Fixes `duster` binary not found because the entrypoint script was flagged to run as a login shell, which re-initializes the env variables. So our ENV line in the Dockerfile file was being ignored.

---

Fixes #3 